### PR TITLE
init: don't reboot to bootloader on panic

### DIFF
--- a/init/Android.mk
+++ b/init/Android.mk
@@ -8,7 +8,7 @@ ifneq (,$(filter userdebug eng,$(TARGET_BUILD_VARIANT)))
 init_options += \
     -DALLOW_LOCAL_PROP_OVERRIDE=1 \
     -DALLOW_PERMISSIVE_SELINUX=1 \
-    -DREBOOT_BOOTLOADER_ON_PANIC=1 \
+    -DREBOOT_BOOTLOADER_ON_PANIC=0 \
     -DDUMP_ON_UMOUNT_FAILURE=1
 else
 init_options += \


### PR DESCRIPTION
Makes device bringups a lot harder.

Change-Id: If6c6f8adebf1c59fc8448f61793c2c3debca6899