### PR TITLE
healthd: Reinitialize mChargerNames for every battery update

### DIFF
--- a/healthd/BatteryMonitor.cpp
+++ b/healthd/BatteryMonitor.cpp
@@ -169,7 +169,7 @@ BatteryMonitor::PowerSupplyType BatteryMonitor::readPowerSupplyType(const String
 
     ret = (BatteryMonitor::PowerSupplyType)mapSysfsString(buf.c_str(), supplyTypeMap);
     if (ret < 0) {
-        KLOG_WARNING(LOG_TAG, "Unknown power supply type '%s'\n", buf.c_str());
+        //KLOG_WARNING(LOG_TAG, "Unknown power supply type '%s'\n", buf.c_str());
         ret = ANDROID_POWER_SUPPLY_TYPE_UNKNOWN;
     }
 
@@ -248,48 +248,79 @@ bool BatteryMonitor::update(void) {
     if (readFromFile(mHealthdConfig->batteryTechnologyPath, &buf) > 0)
         props.batteryTechnology = String8(buf.c_str());
 
-    unsigned int i;
     double MaxPower = 0;
+    // reinitialize the mChargerNames vector everytime there is an update
+    String8 path;
+    DIR* dir = opendir(POWER_SUPPLY_SYSFS_PATH);
+    if (dir == NULL) {
+        KLOG_ERROR(LOG_TAG, "Could not open %s\n", POWER_SUPPLY_SYSFS_PATH);
+    } else {
+        struct dirent* entry;
+        // reconstruct the charger strings
+        mChargerNames.clear();
+        while ((entry = readdir(dir))) {
+            const char* name = entry->d_name;
 
-    for (i = 0; i < mChargerNames.size(); i++) {
-        String8 path;
-        path.appendFormat("%s/%s/online", POWER_SUPPLY_SYSFS_PATH,
-                          mChargerNames[i].string());
-        if (getIntField(path)) {
+            if (!strcmp(name, ".") || !strcmp(name, ".."))
+                continue;
+
+            // Look for "type" file in each subdirectory
             path.clear();
-            path.appendFormat("%s/%s/type", POWER_SUPPLY_SYSFS_PATH,
-                              mChargerNames[i].string());
+            path.appendFormat("%s/%s/type", POWER_SUPPLY_SYSFS_PATH, name);
             switch(readPowerSupplyType(path)) {
             case ANDROID_POWER_SUPPLY_TYPE_AC:
-                props.chargerAcOnline = true;
-                break;
             case ANDROID_POWER_SUPPLY_TYPE_USB:
-                props.chargerUsbOnline = true;
-                break;
             case ANDROID_POWER_SUPPLY_TYPE_WIRELESS:
-                props.chargerWirelessOnline = true;
+                path.clear();
+                path.appendFormat("%s/%s/online", POWER_SUPPLY_SYSFS_PATH, name);
+                if (access(path.string(), R_OK) == 0) {
+                    mChargerNames.add(String8(name));
+                    if (readFromFile(path, &buf) > 0) {
+                        if (buf[0] != '0') {
+                            path.clear();
+                            path.appendFormat("%s/%s/type", POWER_SUPPLY_SYSFS_PATH, name);
+                            switch(readPowerSupplyType(path)) {
+                            case ANDROID_POWER_SUPPLY_TYPE_AC:
+                                props.chargerAcOnline = true;
+                                break;
+                            case ANDROID_POWER_SUPPLY_TYPE_USB:
+                                props.chargerUsbOnline = true;
+                                break;
+                            case ANDROID_POWER_SUPPLY_TYPE_WIRELESS:
+                                props.chargerWirelessOnline = true;
+                                break;
+                            default:
+                                continue;
+                            }
+                            path.clear();
+                            path.appendFormat("%s/%s/current_max", POWER_SUPPLY_SYSFS_PATH, name);
+                            int ChargingCurrent = (access(path.string(), R_OK) == 0) ? getIntField(path) : 0;
+
+                            path.clear();
+                            path.appendFormat("%s/%s/voltage_max", POWER_SUPPLY_SYSFS_PATH, name);
+                            int ChargingVoltage = (access(path.string(), R_OK) == 0) ? getIntField(path) : DEFAULT_VBUS_VOLTAGE;
+                            // there are devices that have the file but with a value of 0
+                            if (ChargingVoltage == 0) {
+                                ChargingVoltage = DEFAULT_VBUS_VOLTAGE;
+                            }
+                            double power = ((double)ChargingCurrent / MILLION) * ((double)ChargingVoltage / MILLION);
+                            if (MaxPower < power) {
+                                props.maxChargingCurrent = ChargingCurrent;
+                                props.maxChargingVoltage = ChargingVoltage;
+                                MaxPower = power;
+                            }
+                        }
+                    }
+                }
+                break;
+            case ANDROID_POWER_SUPPLY_TYPE_BATTERY:
                 break;
             default:
-                KLOG_WARNING(LOG_TAG, "%s: Unknown power supply type\n",
-                             mChargerNames[i].string());
-            }
-
-            int ChargingCurrent =
-                  (access(SYSFS_BATTERY_CURRENT, R_OK) == 0) ? abs(getIntField(String8(SYSFS_BATTERY_CURRENT))) : 0;
-
-            int ChargingVoltage =
-                  (access(SYSFS_BATTERY_VOLTAGE, R_OK) == 0) ? getIntField(String8(SYSFS_BATTERY_VOLTAGE)) :
-                   DEFAULT_VBUS_VOLTAGE;
-
-            double power = ((double)ChargingCurrent / MILLION) *
-                           ((double)ChargingVoltage / MILLION);
-            if (MaxPower < power) {
-                props.maxChargingCurrent = ChargingCurrent;
-                props.maxChargingVoltage = ChargingVoltage;
-                MaxPower = power;
-            }
-        }
-    }
+                break;
+            } //switch
+        } //while
+        closedir(dir);
+    }//else
 
     logthis = !healthd_board_battery_update(&props);
 
@@ -298,12 +329,12 @@ bool BatteryMonitor::update(void) {
         size_t len;
         if (props.batteryPresent) {
             snprintf(dmesgline, sizeof(dmesgline),
-                 "battery l=%d v=%d t=%s%d.%d h=%d st=%d",
+                 "battery l=%d v=%d t=%s%d.%d h=%d st=%d ca=%d cv=%d",
                  props.batteryLevel, props.batteryVoltage,
                  props.batteryTemperature < 0 ? "-" : "",
                  abs(props.batteryTemperature / 10),
                  abs(props.batteryTemperature % 10), props.batteryHealth,
-                 props.batteryStatus);
+                 props.batteryStatus, props.maxChargingCurrent, props.maxChargingVoltage);
 
             len = strlen(dmesgline);
             if (!mHealthdConfig->batteryCurrentNowPath.isEmpty()) {
@@ -473,6 +504,7 @@ void BatteryMonitor::dumpState(int fd) {
 void BatteryMonitor::init(struct healthd_config *hc) {
     String8 path;
     char pval[PROPERTY_VALUE_MAX];
+    std::string buf;
 
     mHealthdConfig = hc;
     std::unique_ptr<DIR, decltype(&closedir)> dir(opendir(POWER_SUPPLY_SYSFS_PATH), closedir);


### PR DESCRIPTION
Booting up the device without usb, the kernel sets the usb power supply
type as UNKNOWN. The type of usb power supply changes at run-time as
various chargers are plugged in/out. However, healthd initilizes the
charger list only at bootup. Change it such that it checks for charger
type changes with every battery or usb uevent.

While at it, the kernel may have a power supply type which is not known
to healthd. This is perfectly fine. Update healthd to not print a
warning.

Change-Id: I2ec9f9a420ca61814d43c316b418ce94de3691bc