### PR TITLE
Added missing AID which is causing setgroups to fail

### DIFF
--- a/libcutils/include/private/android_filesystem_config.h
+++ b/libcutils/include/private/android_filesystem_config.h
@@ -129,6 +129,7 @@
 /* The range 2900-2999 is reserved for OEM, and must never be
  * used here */
 #define AID_OEM_RESERVED_START 2900
+#define AID_QCOM_DIAG 2950          /* access to QTI diagnostic resources */
 #define AID_OEM_RESERVED_END 2999
 
 /* The 3000 series are intended for use as supplemental group id's only.


### PR DESCRIPTION
AID for QCOM_DIAG not being present due to which com.android.phone is killed

Change-Id: Idba1d721042a0c598fc7f4646514363ca04d8bf4