### PR TITLE
Fix charging in lockscreen

### DIFF
--- a/healthd/BatteryMonitor.cpp
+++ b/healthd/BatteryMonitor.cpp
@@ -294,17 +294,14 @@ bool BatteryMonitor::update(void) {
                             default:
                                 continue;
                             }
-                            path.clear();
-                            path.appendFormat("%s/%s/current_max", POWER_SUPPLY_SYSFS_PATH, name);
-                            int ChargingCurrent = (access(path.string(), R_OK) == 0) ? getIntField(path) : 0;
 
-                            path.clear();
-                            path.appendFormat("%s/%s/voltage_max", POWER_SUPPLY_SYSFS_PATH, name);
-                            int ChargingVoltage = (access(path.string(), R_OK) == 0) ? getIntField(path) : DEFAULT_VBUS_VOLTAGE;
-                            // there are devices that have the file but with a value of 0
-                            if (ChargingVoltage == 0) {
-                                ChargingVoltage = DEFAULT_VBUS_VOLTAGE;
-                            }
+            int ChargingCurrent =
+                  (access(SYSFS_BATTERY_CURRENT, R_OK) == 0) ? abs(getIntField(String8(SYSFS_BATTERY_CURRENT))) : 0;
+
+            int ChargingVoltage =
+                  (access(SYSFS_BATTERY_VOLTAGE, R_OK) == 0) ? getIntField(String8(SYSFS_BATTERY_VOLTAGE)) :
+                   DEFAULT_VBUS_VOLTAGE;
+
                             double power = ((double)ChargingCurrent / MILLION) * ((double)ChargingVoltage / MILLION);
                             if (MaxPower < power) {
                                 props.maxChargingCurrent = ChargingCurrent;


### PR DESCRIPTION
Current voltage and battery in time real

*To enable this:
BOARD_GLOBAL_CFLAGS += -DBATTERY_REAL_INFO

need to add the BOARD_GLOBAL_CFLAGS call in the build tree in the device BoardConfig

Credits by AospExtend